### PR TITLE
Modified the codebook class to be able to select vector bit width+some

### DIFF
--- a/BiBench/.gitignore
+++ b/BiBench/.gitignore
@@ -3,3 +3,4 @@ data/
 *.pyc
 __pycache__/
 .vscode/
+data/

--- a/BiBench/bibench/models/layers/__init__.py
+++ b/BiBench/bibench/models/layers/__init__.py
@@ -1,0 +1,1 @@
+__all__=['BinaryCodebook','CodebookReplacer']

--- a/BiBench/bibench/models/layers/builder.py
+++ b/BiBench/bibench/models/layers/builder.py
@@ -8,7 +8,7 @@ from .dorefa import DoReFaConv2d, DoReFaConv1d, DoReFaLinear
 from .xnorplusplus import XNORPlusPlusConv2d, XNORPlusPlusConv1d, XNORPlusPlusLinear
 from .recu import ReCUConv2d, ReCUConv1d, ReCULinear
 from .fda import FDAConv2d, FDAConv1d, FDALinear
-
+from .custom_bnn import CBNNConv2d
 from mmcv.cnn import CONV_LAYERS
 
 
@@ -24,6 +24,7 @@ def init_layers():
     CONV_LAYERS.register_module(name='XNORPlusPlusConv', module=XNORPlusPlusConv2d)
     CONV_LAYERS.register_module(name='ReCUConv', module=ReCUConv2d)
     CONV_LAYERS.register_module(name='FDAConv', module=FDAConv2d)
+    CONV_LAYERS.register_module(name='CBNNConv', module=CBNNConv2d)
 
     CONV_LAYERS.register_module(name='BiRealConv2d', module=BiRealConv2d)
     CONV_LAYERS.register_module(name='XNORConv2d', module=XNORConv2d)
@@ -33,6 +34,7 @@ def init_layers():
     CONV_LAYERS.register_module(name='XNORPlusPlusConv2d', module=XNORPlusPlusConv2d)
     CONV_LAYERS.register_module(name='ReCUConv2d', module=ReCUConv2d)
     CONV_LAYERS.register_module(name='FDAConv2d', module=FDAConv2d)
+    CONV_LAYERS.register_module(name='CBNNConv2d', module=CBNNConv2d)
 
     CONV_LAYERS.register_module(name='BiRealConv1d', module=BiRealConv1d)
     CONV_LAYERS.register_module(name='XNORConv1d', module=XNORConv1d)

--- a/BiBench/bibench/models/layers/custom_bnn.py
+++ b/BiBench/bibench/models/layers/custom_bnn.py
@@ -1,0 +1,111 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from  .coding import *
+
+class CBNNConv2d(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, padding=0, bias=False, dilation=0, transposed=False, output_padding=None, groups=1):
+        super(CBNNConv2d, self).__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.padding = padding
+        self.dilation = dilation
+        self.transposed = transposed
+        self.output_padding = output_padding
+        self.groups = groups
+        self.number_of_weights = in_channels * out_channels * kernel_size * kernel_size
+        self.shape = (out_channels, in_channels, kernel_size, kernel_size)
+        self.weight = nn.Parameter(torch.rand(*self.shape) * 0.002 - 0.001, requires_grad=True)
+        self.coder = BinaryCodebook()
+        self.register_buffer('codebook', None)
+        self.register_buffer('encoded_vector', None)
+        self.codebook, self.encoded_vector = self.coder.process_weights(self.weight)
+        self.first_iter=True
+
+    def forward(self, x):
+        if self.training:
+            if not self.first_iter:
+                _ , self.encoded_vector=CodebookReplacer.replace_with_codebook(  self.codebook,k_bits=9)
+            binary_input_no_grad = torch.sign(x)
+            cliped_input = torch.clamp(x, -1.0, 1.0)
+            x = binary_input_no_grad.detach() - cliped_input.detach() + cliped_input
+
+            real_weights = self.weight.view(self.shape)
+            binary_weights_no_grad = CodebookReplacer.weight_builder(self.codebook,self.encoded_vector,self.shape)
+            cliped_weights = torch.clamp(real_weights, -1.0, 1.0)
+            binary_weights = binary_weights_no_grad.detach() - cliped_weights.detach() + cliped_weights
+            y = F.conv2d(x, binary_weights, stride=self.stride, padding=self.padding)
+
+            return y
+        else:
+            x = torch.sign(x)
+            encoded_vectors = torch.tensor(self.encoded_vector, dtype=torch.long)
+            binary_weights = self.codebook[encoded_vectors]
+            binary_weights = binary_weights.view((self.shape))
+            y = F.conv2d(x, binary_weights, stride=self.stride, padding=self.padding)
+            return y
+           
+
+class CBNNConv1d(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, padding=0, bias=False, dilation=0, transposed=False, output_padding=None, groups=1):
+        super(BNNConv1d, self).__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.padding = padding
+        self.dilation = dilation
+        self.transposed = transposed
+        self.output_padding = output_padding
+        self.groups = groups
+        self.number_of_weights = in_channels * out_channels * kernel_size
+        self.shape = (out_channels, in_channels, kernel_size)
+        self.weight = nn.Parameter(torch.rand(*self.shape) * 0.001, requires_grad=True)
+
+    def forward(self, x):
+        binary_input_no_grad = torch.sign(x)
+        cliped_input = torch.clamp(x, -1.0, 1.0)
+        x = binary_input_no_grad.detach() - cliped_input.detach() + cliped_input
+
+        real_weights = self.weight.view(self.shape)
+        binary_weights_no_grad = torch.sign(real_weights)
+        cliped_weights = torch.clamp(real_weights, -1.0, 1.0)
+        binary_weights = binary_weights_no_grad.detach() - cliped_weights.detach() + cliped_weights
+        y = F.conv1d(x, binary_weights, stride=self.stride, padding=self.padding)
+
+        return y
+
+
+class BinaryQuantize(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input):
+        ctx.save_for_backward(input)
+        out = torch.sign(input)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input = ctx.saved_tensors
+        grad_input = grad_output
+        grad_input[input[0].gt(1)] = 0
+        grad_input[input[0].lt(-1)] = 0
+        return grad_input
+
+
+class BNNLinear(nn.Linear):
+    def __init__(self, in_features, out_features, bias=True, binary_act=True):
+        super(BNNLinear, self).__init__(in_features, out_features, bias=True)
+        self.binary_act = binary_act
+        self.output_ = None
+
+    def forward(self, input):
+        bw = self.weight
+        ba = input
+        bw = BinaryQuantize().apply(bw)
+        if self.binary_act:
+            ba = BinaryQuantize().apply(ba)
+        output = F.linear(ba, bw, self.bias)
+        self.output_ = output
+        return output

--- a/BiBench/configs/acc_cifar10/resnet34_cbnn_adam_1e-3_cosinelr.py
+++ b/BiBench/configs/acc_cifar10/resnet34_cbnn_adam_1e-3_cosinelr.py
@@ -1,0 +1,17 @@
+_base_ = [
+    '../_base_/models/resnet34.py', '../_base_/datasets/cifar10.py',
+    '../_base_/schedules/adam_1e-3_cosinelr_200e.py', '../_base_/default_runtime.py'
+]
+
+model = dict(
+    arch=dict(
+        backbone=dict(
+            type='BiBench_ResNet_CIFAR',
+            conv_cfg=dict(type='CBNNConv'),
+            first_act_cfg=dict(type='Hardtanh', inplace=True),
+            act_cfg=dict(type='Hardtanh', inplace=True)
+        ),
+        head=dict(num_classes=10)
+     )#,
+    # init_cfg=dict(type='Pretrained', checkpoint='data/pretrained/res34_cifar10.pth')
+)

--- a/BiBench/tools/train.py
+++ b/BiBench/tools/train.py
@@ -16,7 +16,7 @@ from bibench.apis import set_random_seed, train_model
 from bibench.datasets import build_dataset
 from bibench.models import build_architecture
 from bibench.utils import collect_env, get_root_logger
-from bibench.ext.coding import BinaryCodebook, CodebookReplacer
+#from bibench.ext.coding import BinaryCodebook, CodebookReplacer
 
 
 def parse_args():
@@ -129,16 +129,16 @@ def main():
     meta['seed'] = args.seed
 
     model = build_architecture(cfg.model)
-    import pdb; pdb.set_trace()
+    # import pdb; pdb.set_trace()
 
-    coder = BinaryCodebook(k=256, max_iter=20)
-    for name, mod in model.named_models():
-        if isinstance(mod, torch.nn.Conv2d):
-            import pdb; pdb.set_trace()
-            weights = getattr(mod, "weights")
-            codebook, encoded_vector = coder.process_weights(weights)
-            setattr(mod, "codebook", codebook)
-            setattr(mod, "encoded_vector", encoded_vector)
+    # coder = BinaryCodebook(k=256, max_iter=20)
+    # for name, mod in model.named_models():
+    #     if isinstance(mod, torch.nn.Conv2d):
+    #         import pdb; pdb.set_trace()
+    #         weights = getattr(mod, "weights")
+    #         codebook, encoded_vector = coder.process_weights(weights)
+    #         setattr(mod, "codebook", codebook)
+    #         setattr(mod, "encoded_vector", encoded_vector)
     model.init_weights()
     datasets = [build_dataset(cfg.data.train)]
     if len(cfg.workflow) == 2:


### PR DESCRIPTION
minor changes.
Changed the code replacer class to use only static methods + minor changes.
removed the coder from train.py and removed also the debuger. added custom bnn layer and new configration file for the training. the coder is used now in each custom layer.
added the custom bnn layer to the builder.
training is now possible.
**still to be fixed**
warning message about memory leak due to using kmean from sklearn. warning message about a variable that might be better to clone. room for optimization.
slow convergence(might be learning rate or that the train.py intializes the weights again after the codebook have been created during)